### PR TITLE
Fix null unit on status monitoring graph

### DIFF
--- a/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
+++ b/sysutils/pfSense-Status_Monitoring/files/usr/local/www/status_monitoring.php
@@ -1231,7 +1231,7 @@ events.push(function() {
 							var adjustedTrueValue = d3.format(',')(trueValue.toFixed(2));
 						}
 
-						content += '<tr><td class="legend-color-guide"><div style="background-color: ' + data.series[v].color + '"></div></td><td>' + data.series[v].key + '</td><td class="value"><strong>' + adjustedTrueValue + " " + localStorage.getItem(tempKey) + '</strong></td></tr>';
+						content += '<tr><td class="legend-color-guide"><div style="background-color: ' + data.series[v].color + '"></div></td><td>' + data.series[v].key + '</td><td class="value"><strong>' + adjustedTrueValue + " " + localStorage.getItem(data.series[v].key) + '</strong></td></tr>';
 					}
 
 					content += '</tbody></table>';


### PR DESCRIPTION
When localStorage is cleared and you add a right axis field that has units other than the main left axis, the units will be "null" due to the tempKey stripping out the "(right axis)" from the key and thus not finding a match in localStorage.

![2016-05-19_09-16-37_firefox](https://cloud.githubusercontent.com/assets/13368604/15401050/af961606-1da2-11e6-91fe-d3d0123bf6af.png)
